### PR TITLE
Api doc quick fix

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -33,14 +33,6 @@ jobs:
     - name: Git Repos Update
       run: | 
         chmod +x ./.github/scripts/clone.sh
-        git clone https://github.com/ifm/ifm3d sphinx-doc/source/ifm3d
-        cd sphinx-doc/source/ifm3d
-        git checkout v1.0.1
-        cd ../../..
-        git clone https://github.com/ifm/ifm3d-docs sphinx-doc/etc/ifm3d-docs
-        cd sphinx-doc/etc/ifm3d-docs
-        git checkout 85d8e91d1a3fa34dbd93f7b13756a64c7872a563
-        cd ../../..
         ./.github/scripts/clone.sh https://github.com/ifm/documentation main sphinx-doc/source/documentation
         ./.github/scripts/clone.sh https://github.com/ifm/ifm3d-ros.git master sphinx-doc/source/ROS/ifm3d-ros  
         ./.github/scripts/clone.sh https://github.com/ifm/ifm3d-ros2.git master sphinx-doc/source/ROS/ifm3d-ros2      
@@ -51,11 +43,7 @@ jobs:
       run: |
         cd sphinx-doc 
         rm -r -f build
-        cp source/ifm3d/README.md source/ifm3d/doc/sphinx/content
-        mkdir -p source/ifm3d/doc/sphinx/content/examples
-        cp -r -n source/ifm3d/examples/* source/ifm3d/doc/sphinx/content/examples
         make html
-        cp -r etc/ifm3d-docs/html/cpp_api build/html/ifm3d/doc/sphinx/
     - name: Push built docs
       run: |
         git config --global user.email "support.robotics@ifm.com"

--- a/sphinx-doc/source/ifm3d/index.md
+++ b/sphinx-doc/source/ifm3d/index.md
@@ -1,0 +1,5 @@
+# ifm3d library
+
+```{admonition} News
+Site under construction: We are in the process of re-designing our documentation portal. Until this is finalized, please use the ifm3d documentation available [here](https://ifm.github.io/ifm3d-docs/html/index.html).
+```

--- a/sphinx-doc/source/index.md
+++ b/sphinx-doc/source/index.md
@@ -5,7 +5,7 @@ Welcome to the O3R's documentation!
 
 :::{toctree}
 O3R <documentation/O3R/README>
-ifm3d library <ifm3d/doc/sphinx/index>
+ifm3d library <ifm3d/index>
 ROS packages <ROS/index>
 Downloads <downloadable/index>
 :::


### PR DESCRIPTION
Removes the generation of doc for ifm3d.  
Add link to external ifm3d doc pages.

Note: this is a temporary fix until the ifm3d docs if migrated to a subdomain of ifm3d.com